### PR TITLE
bug fix: ReAuthable is not resetting the connection when session expires

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
         <dependency>
                <groupId>org.codehaus.jackson</groupId>
                <artifactId>jackson-core-asl</artifactId>
-               <version>1.7.3</version>
+               <version>1.9.13</version>
        </dependency>
        <dependency>
                <groupId>org.codehaus.jackson</groupId>
                <artifactId>jackson-mapper-asl</artifactId>
-               <version>1.7.3</version>
+               <version>1.9.13</version>
        </dependency>
        <dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/sparkplatform/api/SparkAPI.java
+++ b/src/main/java/com/sparkplatform/api/SparkAPI.java
@@ -22,6 +22,7 @@ import com.sparkplatform.api.core.Client;
 import com.sparkplatform.api.core.Configuration;
 import com.sparkplatform.api.core.Connection;
 import com.sparkplatform.api.core.ConnectionApacheHttp;
+import com.sparkplatform.api.core.ISessionListener;
 import com.sparkplatform.api.core.Response;
 import com.sparkplatform.api.core.Session;
 
@@ -229,6 +230,7 @@ public class SparkAPI extends Client {
 		try {
 			Response response = getConnection().post(getSparkOAuth2GrantPath(),getOAuthRequestJSON("refresh_token", null, getSparkSession().getRefreshToken()));
 			s = getAuthSession(response);
+			setSession(s);
 		} catch (Exception e) {
 			throw new SparkAPIClientException("Session mapping error",e);
 		}

--- a/src/main/java/com/sparkplatform/api/core/ApiCode.java
+++ b/src/main/java/com/sparkplatform/api/core/ApiCode.java
@@ -26,23 +26,48 @@ import java.util.Map;
  * @see http://www.flexmls.com/developers/idx-api/supporting-documentation/error-codes/
  */
 public enum ApiCode {
-	NOT_FOUND(404), 
-	NOT_ALLOWED(405), 
+	NOT_FOUND(404, "Not found"), 
+	NOT_ALLOWED(405, "Method not allowed"), 
 
-	INVALID_KEY(1000), 
-	DISABLED_KEY(1010), 
-	SESSION_EXPIRED(1020), 
-	SSL_REQUIRED(1030), 
-	INVALID_JSON(1035), 
-	INVALID_FILTER(1040), 
-	MISSING_PARAMETER(1050), 
-	INVALID_PARAMETER(1053), 
-	INVALID_WRITE(1055), 
+	INVALID_KEY(1000, "Invalid API key and/or request signed improperly"), 
+	DISABLED_KEY(1010, "API key is disabled"), 
+	AUTH_NOT_PERMITTED(1013, "The auth mechanism used for this request is not permitted for the provided key"), 
+	API_USER_REQUIRED(1015, "ApiUser must be supplied, or the provided key does not have access to the supplied user"), 
+	X_SPARK_API_USER_AGENT_REQUIRED(1016, "The X-SparkApi-User-Agent request header is required. No request to the API will be successful without it. Please see the overview for additional information."), 
+	READ_ONLY_ACCESS(1017, "You are restricted to read-only access. POST, PUT, and DELETE requests are forbidden."), 
+	FORBIDDEN(1018, "You are forbidden from accessing this resource with the method attempted"), 
+	SESSION_EXPIRED(1020, "Session token has expired"), 
+	USER_ACCOUNT_NOT_AVAILABLE(1023, "The user's account is not yet available in Spark."), 
+	PORTAL_GROUP_INVALID(1025, "The user has a Portal Group selected that is no longer valid. Set a new portal group before accessing this service."), 
+	SSL_REQUIRED(1030, "SSL required for this type of request"), 
+	INVALID_JSON(1035, "POST data not supplied as valid JSON. Issued if the \"Content-Type\" header is not \"application/json\" and/or if the POST data is not in valid JSON format"), 
+	INVALID_FILTER(1040, "The _filter syntax was invalid or a specified field to search on does not exist. Response will include the SparkQLErrors attribute."), 
+	FILTER_EXCEEDS_RESTRICTIONS(1041, "(Message varies) The _filter syntax is valid but exceeds restrictions on filter or argument length Response will include the SparkQLErrors attribute."), 
+	MISSING_PARAMETER(1050, "(Message varies) A required parameter for the request was not provided"), 
+	INVALID_PARAMETER(1053, "(Message varies) A parameter was provided but does not adhere to constraints"), 
+	INVALID_WRITE(1055, "(Message varies) Issued when a write is requested that will conflict with existing data. For instance, adding a new contact with an e-mail that already exists"), 
+	DATA_VALIDATION_FAILED(1060, "(Message varies) A Validation field did not match existing data"), 
+	PREVIOUS_DATA_PROHIBITED(1061, "(Message varies) Attempt to reuse previous data when prohibited"), 
 	
-	RESOURCE_UNAVAILABLE(1500), 
-	RATE_LIMIT_EXCEEDED(1550),
+	PORTAL_REQUIRED(1100, "This resource cannot be accessed until a Portal account is created for the specified contact"), 
+	PORTAL_ALREADY_EXISTS(1110, "A portal already exists for this contact"), 
+	RESOURCE_UNAVAILABLE(1500, "The resource is not available at the current API key's service level. For example, this error applies if a user attempts to access the IDX Links API via a non-IDX API key."), 
+	RESOURCE_DISABLED(1505, "(Message varies) This resource, or a component of this resource, is disabled for the current user's MLS. This is usually temporary, such as during a gradual rollout of a feature."), 
+	TEMPORARY_UNAVAILABLE(1510, "The API is temporarily unavailable."), 
+	LONG_REQUEST_CANCELLED(1515, "Your request took too long to process and has therefore been cancelled."), 
+	LONG_REQUEST_FILTER_OR_ORDERBY_CANCELLED(1516, "Your request took too long to process and was cancelled due to the _filter or _orderby parameter you provided."), 
+	RATE_LIMIT_EXCEEDED(1550, "Over rate limit"),
+
+	RESERVED(2000, "Codes 2000-2999 are reserved for value-specific errors in the _filter parameter. These are not syntax errors, but instead errors specific to the valid field present in the parameter. Responses will include the SparkQLErrors attribute."),
+	SAVED_SEARCH_UNAVAILBLE(2001, "The SavedSearch specified does not exist or is not available to the current user."),
+	EMAIL_LINK_UNAVAILBLE(2002, "The EmailLink specified does not exist or is not available to the current user."),
+	SHARED_LISTINGS_ID_UNAVAILABLE(2003, "The SharedListings id specified does not exist or does not contain listings."),
+	SEARCH_CRITERIA_RESTRICTIONS(2500, "The search you are attempting to subscribe to does not meet the search criteria restrictions."),
+	USER_ALREADY_SUBSCRIBED_TO_SEARCH(2505, "The current user is already subscribed to this saved search."),
+	RESO_VERSION_NOT_SUPPORTED(3000, "The RESO data dictionary version you requested is not supported."),
+	
 	// For missing codes that the library doesn't know about yet.
-	UNKNOWN_API_CODE(0);
+	UNKNOWN_API_CODE(0, "");
 
 	private static final Map<Integer, ApiCode> MAP = new HashMap<Integer, ApiCode>();
 
@@ -53,9 +78,11 @@ public enum ApiCode {
 	}
 
 	private int code;
+	private String message;
 
-	private ApiCode(int code) {
+	private ApiCode(int code, String message) {
 		this.code = code;
+		this.message = message;
 	}
 
 	/**
@@ -64,6 +91,10 @@ public enum ApiCode {
 	 */
 	public int getCode() {
 		return code;
+	}
+
+	public String getMessage() {
+		return message;
 	}
 
 	/**

--- a/src/main/java/com/sparkplatform/api/core/BaseClient.java
+++ b/src/main/java/com/sparkplatform/api/core/BaseClient.java
@@ -29,6 +29,7 @@ import org.apache.log4j.Logger;
 
 import com.sparkplatform.api.SparkAPIClientException;
 import com.sparkplatform.api.SparkAPIException;
+import com.sparkplatform.api.SparkSession;
 
 /**
  * Client class for communicating with the flexmls restful interface.  Abstracts the HTTP,
@@ -44,6 +45,7 @@ public abstract class BaseClient<U> implements HttpActions<Response, U>{
 	private Connection<Response> connection;
 	private Connection<Response> secure;
 	private Session session;
+	private ISessionListener sessionListener;
 
 	/**
 	 * Configure the client with general settings, and connection implementations
@@ -217,6 +219,8 @@ public abstract class BaseClient<U> implements HttpActions<Response, U>{
 
 	public void setSession(Session session) throws SparkAPIClientException {
 		this.session = session;
+		if (sessionListener!=null)
+			sessionListener.sessionChanged( session );
 	}
 
 	public Configuration getConfig() {
@@ -271,6 +275,14 @@ public abstract class BaseClient<U> implements HttpActions<Response, U>{
 			throw new SparkAPIClientException("Session expired and maximum number of authentication attempts reached.");
 		}
 		protected abstract Response run(String path, String body) throws SparkAPIClientException;
+	}
+
+	public ISessionListener getSessionListener() {
+		return sessionListener;
+	}
+
+	public void setSessionListener( ISessionListener sessionListener ) {
+		this.sessionListener = sessionListener;
 	}
 
 }

--- a/src/main/java/com/sparkplatform/api/core/ISessionListener.java
+++ b/src/main/java/com/sparkplatform/api/core/ISessionListener.java
@@ -1,0 +1,6 @@
+package com.sparkplatform.api.core;
+
+
+public interface ISessionListener {
+	public void sessionChanged(Session session);
+}

--- a/src/main/java/com/sparkplatform/api/core/JsonResponseHandler.java
+++ b/src/main/java/com/sparkplatform/api/core/JsonResponseHandler.java
@@ -85,6 +85,10 @@ public class JsonResponseHandler implements ResponseHandler<Response> {
 		{
 			r = new Response(mapper,root);
 			r.setSuccess(root.get("error") == null);
+			r.setStatus(status);
+			if (!r.isSuccess()) {
+				r.setMessage(root.get("error_description").getTextValue());
+			}
 		}
 			
 		return r;		

--- a/src/main/java/com/sparkplatform/api/models/CustomField.java
+++ b/src/main/java/com/sparkplatform/api/models/CustomField.java
@@ -56,7 +56,7 @@ public class CustomField extends Base {
 				JsonProcessingException {
 			JavaType jt = TypeFactory.mapType(Map.class, String.class, Field.class);
 			DeserializerProvider deserializerProvider = ctxt.getDeserializerProvider();
-			JsonDeserializer<Object> z = deserializerProvider.findTypedValueDeserializer(ctxt.getConfig(), jt);
+			JsonDeserializer<Object> z = deserializerProvider.findTypedValueDeserializer(ctxt.getConfig(), jt, null);
 			@SuppressWarnings("unchecked")
 			Map<String, Field>o = (Map<String, Field>)z.deserialize(jp, ctxt);
 			if(o == null) {

--- a/src/main/java/com/sparkplatform/api/models/CustomFieldResults.java
+++ b/src/main/java/com/sparkplatform/api/models/CustomFieldResults.java
@@ -55,7 +55,7 @@ public class CustomFieldResults extends Base {
 				JsonProcessingException {
 			JavaType jt = TypeFactory.mapType(Map.class, String.class, Result.class);
 			DeserializerProvider deserializerProvider = ctxt.getDeserializerProvider();
-			JsonDeserializer<Object> z = deserializerProvider.findTypedValueDeserializer(ctxt.getConfig(), jt);
+			JsonDeserializer<Object> z = deserializerProvider.findTypedValueDeserializer(ctxt.getConfig(), jt, null);
 			@SuppressWarnings("unchecked")
 			Map<String, Result>o = (Map<String, Result>)z.deserialize(jp, ctxt);
 			if(o == null) {

--- a/src/main/java/com/sparkplatform/api/models/DateField.java
+++ b/src/main/java/com/sparkplatform/api/models/DateField.java
@@ -1,0 +1,43 @@
+package com.sparkplatform.api.models;
+
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class DateField implements Serializable {
+	private static final long serialVersionUID = 21L;
+
+	private static final SimpleDateFormat ISO_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX", Locale.US);
+	private Date value;
+	private boolean restricted = false;
+	public DateField(String str) {
+		if ("********".equals( str )) {
+			restricted = true;
+		} else {
+			try {
+				value = ISO_FORMAT.parse(str);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not parse date: "+str, e);
+			}
+		}
+	}
+	public Date getValue() {
+		return value;
+	}
+	public void setValue( Date value ) {
+		this.value = value;
+	}
+	public boolean isRestricted() {
+		return restricted;
+	}
+	public void setRestricted( boolean restricted ) {
+		this.restricted = restricted;
+	}
+	public String toString() {
+		if (restricted)
+			return "********";
+		else
+			return value.toString();
+	}
+}

--- a/src/main/java/com/sparkplatform/api/models/DoubleField.java
+++ b/src/main/java/com/sparkplatform/api/models/DoubleField.java
@@ -1,0 +1,50 @@
+package com.sparkplatform.api.models;
+
+import java.io.Serializable;
+
+public class DoubleField implements Serializable {
+	private static final long serialVersionUID = 22L;
+
+	private Double value;
+	private boolean restricted = false;
+	public DoubleField(String str) {
+		if ("********".equals( str )) {
+			restricted = true;
+		} else {
+			try {
+				value = Double.valueOf(str);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not parse Double: "+str, e);
+			}
+		}
+	}
+	public DoubleField(int val) {
+		value = Double.valueOf( val );
+	}
+	public DoubleField(long val) {
+		value = Double.valueOf( val );
+	}
+	public DoubleField(double val) {
+		value = Double.valueOf( val );
+	}
+	public Double getValue() {
+		return value;
+	}
+	public void setValue( Double value ) {
+		this.value = value;
+	}
+	public boolean isRestricted() {
+		return restricted;
+	}
+	public void setRestricted( boolean restricted ) {
+		this.restricted = restricted;
+	}
+	public String toString() {
+		if (restricted)
+			return "********";
+		else if (value!=null)
+			return value.toString();
+		else
+			return "";
+	}
+}

--- a/src/main/java/com/sparkplatform/api/models/IntegerField.java
+++ b/src/main/java/com/sparkplatform/api/models/IntegerField.java
@@ -1,0 +1,51 @@
+package com.sparkplatform.api.models;
+
+import java.io.Serializable;
+
+public class IntegerField implements Serializable {
+	private static final long serialVersionUID = 23L;
+
+	private Integer value;
+	private boolean restricted = false;
+	public IntegerField(String str) {
+		if ("********".equals( str )) {
+			restricted = true;
+		} else if (str==null) {
+		} else {
+			try {
+				value = Integer.valueOf(str);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not parse Integer: "+str, e);
+			}
+		}
+	}
+	public IntegerField(int val) {
+		value = Integer.valueOf( val );
+	}
+	public IntegerField(long val) {
+		value = Integer.valueOf( (int)val );
+	}
+	public IntegerField(double val) {
+		value = Integer.valueOf( (int)val );
+	}
+	public Integer getValue() {
+		return value;
+	}
+	public void setValue( Integer value ) {
+		this.value = value;
+	}
+	public boolean isRestricted() {
+		return restricted;
+	}
+	public void setRestricted( boolean restricted ) {
+		this.restricted = restricted;
+	}
+	public String toString() {
+		if (restricted)
+			return "********";
+		else if (value!=null)
+			return value.toString();
+		else
+			return "";
+	}
+}

--- a/src/main/java/com/sparkplatform/api/models/Listing.java
+++ b/src/main/java/com/sparkplatform/api/models/Listing.java
@@ -37,219 +37,693 @@ public class Listing extends ResourceEntity {
 	}
 	
 	public static class StandardFields extends Base {
-		
 		private static final long serialVersionUID = 6L;
 		
-	    @JsonProperty("StreetNumber")
-	    private String streetNumber;
-	    @JsonProperty("Longitude")
-	    private String longitude;
-	    @JsonProperty("City")
-	    private String city;
-	    @JsonProperty("ListingId")
-	    private String listingId;
-	    @JsonProperty("PublicRemarks")
-	    private String publicRemarks;
-	    @JsonProperty("BuildingAreaTotal")
-	    private String buildingAreaTotal;
-	    @JsonProperty("YearBuilt")
-	    private int yearBuilt;
-	    @JsonProperty("StreetName")
-	    private String streetName;
-	    @JsonProperty("ListPrice")
-	    private Double listPrice;
-	    @JsonProperty("PostalCode")
-	    private String postalCode;
-	    @JsonProperty("Latitude")
-	    private String latitude;
-	    @JsonProperty("BathsThreeQuarter")
-	    private String bathsThreeQuarter;
-	    @JsonProperty("BathsFull")
-	    private String bathsFull;
-	    @JsonProperty("BathsTotal")
-	    private Double bathsTotal;
-	    @JsonProperty("StateOrProvince")
-	    private String stateOrProvince;
-	    @JsonProperty("PropertyType")
-	    private String propertyType;
-	    @JsonProperty("StreetAdditionalInfo")
-	    private String streetAdditionalInfo;
-	    @JsonProperty("StreetDirPrefix")
-	    private String streetDirPrefix;
-	    @JsonProperty("BedsTotal")
-	    private String bedsTotal;
-	    @JsonProperty("StreetDirSuffix")
-	    private String streetDirSuffix;
-	    @JsonProperty("ListingKey")
-	    private String listingKey;
-	    @JsonProperty("ListOfficeName")
-	    private String listOfficeName;
-	    @JsonProperty("BathsHalf")
-	    private String bathsHalf;
-	    @JsonProperty("ModificationTimestamp")
-	    private Date modificationTimestamp;
-	    @JsonProperty("CountyOrParish")
-	    private String countyOrParish;
-	    @JsonProperty("StreetSuffix")
-	    private String streetSuffix;
-	    
-		public String getStreetNumber() {
-			return streetNumber;
+		@JsonProperty("ListingKey")
+		private String listingKey;
+		@JsonProperty("ListingId")
+		private String listingId;
+		@JsonProperty("PropertyType")
+		private String propertyType;
+		@JsonProperty("PropertySubType")
+		private String propertySubType;
+		@JsonProperty("ListPrice")
+		private DoubleField listPrice;
+
+		@JsonProperty("BathsFull")
+		private IntegerField bathsFull;
+		@JsonProperty("BathsHalf")
+		private IntegerField bathsHalf;
+		@JsonProperty("BathsThreeQuarter")
+		private IntegerField bathsThreeQuarter;
+		@JsonProperty("BathsTotal")
+		private DoubleField bathsTotal;
+		@JsonProperty("BedsTotal")
+		private IntegerField bedsTotal;
+		@JsonProperty("BuildingAreaTotal")
+		private DoubleField buildingAreaTotal;
+
+		@JsonProperty("StreetNumber")
+		private String streetNumber;
+		@JsonProperty("StreetDirPrefix")
+		private String streetDirPrefix;
+		@JsonProperty("StreetName")
+		private String streetName;
+		@JsonProperty("StreetSuffix")
+		private String streetSuffix;
+		@JsonProperty("StreetDirSuffix")
+		private String streetDirSuffix;
+		@JsonProperty("StreetAdditionalInfo")
+		private String streetAdditionalInfo;
+		@JsonProperty("City")
+		private String city;
+		@JsonProperty("StateOrProvince")
+		private String stateOrProvince;
+		@JsonProperty("PostalCode")
+		private String postalCode;
+		@JsonProperty("YearBuilt")
+		private IntegerField yearBuilt;
+		@JsonProperty("Longitude")
+		private DoubleField longitude;
+		@JsonProperty("Latitude")
+		private DoubleField latitude;
+		@JsonProperty("SubdivisionName")
+		private String subdivisionName;
+		@JsonProperty("MLSAreaMinor")
+		private String mLSAreaMinor;
+		@JsonProperty("CountyOrParish")
+		private String countyOrParish;
+		@JsonProperty("PublicRemarks")
+		private String publicRemarks;
+		@JsonProperty("privateRemarks")
+		private String privateRemarks;
+		@JsonProperty("privateOfficeRemarks")
+		private String privateOfficeRemarks;
+		@JsonProperty("PendingDate")
+		private DateField pendingDate;
+		@JsonProperty("CloseDate")
+		private DateField closeDate;
+		@JsonProperty("CancelDate")
+		private DateField cancelDate;
+		@JsonProperty("WithdrawDate")
+		private DateField withdrawDate;
+		@JsonProperty("ListAgentFirstName")
+		private String listAgentFirstName;
+		@JsonProperty("ListAgentMiddleName")
+		private String listAgentMiddleName;
+		@JsonProperty("ListAgentLastName")
+		private String listAgentLastName;
+		@JsonProperty("ListAgentPreferredPhone")
+		private String listAgentPreferredPhone;
+		@JsonProperty("ListAgentPreferredPhoneExt")
+		private String listAgentPreferredPhoneExt;
+		@JsonProperty("ListAgentOfficePhone")
+		private String listAgentOfficePhone;
+		@JsonProperty("ListAgentOfficePhoneExt")
+		private String listAgentOfficePhoneExt;
+		@JsonProperty("ListAgentCellPhone")
+		private String listAgentCellPhone;
+		@JsonProperty("ListAgentDirectPhone")
+		private String listAgentDirectPhone;
+		@JsonProperty("ListAgentTollFreePhone")
+		private String listAgentTollFreePhone;
+		@JsonProperty("ListAgentFax")
+		private String listAgentFax;
+		@JsonProperty("ListAgentPager")
+		private String listAgentPager;
+		@JsonProperty("ListAgentVoiceMail")
+		private String listAgentVoiceMail;
+		@JsonProperty("ListAgentVoiceMailExt")
+		private String listAgentVoiceMailExt;
+		@JsonProperty("ListAgentEmail")
+		private String listAgentEmail;
+		@JsonProperty("ListAgentURL")
+		private String listAgentURL;
+		@JsonProperty("ListAgentStateLicense")
+		private String listAgentStateLicense;
+		@JsonProperty("ListAgentDesignation")
+		private String listAgentDesignation;
+		@JsonProperty("ListOfficeName")
+		private String listOfficeName;
+		@JsonProperty("ListOfficePhone")
+		private String listOfficePhone;
+		@JsonProperty("ListOfficePhoneExt")
+		private String listOfficePhoneExt;
+		@JsonProperty("ListOfficeFax")
+		private String listOfficeFax;
+		@JsonProperty("ListOfficeEmail")
+		private String listOfficeEmail;
+		@JsonProperty("ListOfficeURL")
+		private String listOfficeURL;
+		@JsonProperty("CoListAgentFirstName")
+		private String coListAgentFirstName;
+		@JsonProperty("CoListAgentMiddleName")
+		private String coListAgentMiddleName;
+		@JsonProperty("CoListAgentLastName")
+		private String coListAgentLastName;
+		@JsonProperty("CoListAgentPreferredPhone")
+		private String coListAgentPreferredPhone;
+		@JsonProperty("CoListAgentPreferredPhoneExt")
+		private String coListAgentPreferredPhoneExt;
+		@JsonProperty("CoListAgentOfficePhone")
+		private String coListAgentOfficePhone;
+		@JsonProperty("CoListAgentOfficePhoneExt")
+		private String coListAgentOfficePhoneExt;
+		@JsonProperty("CoListAgentCellPhone")
+		private String coListAgentCellPhone;
+		@JsonProperty("CoListAgentDirectPhone")
+		private String coListAgentDirectPhone;
+		@JsonProperty("CoListAgentTollFreePhone")
+		private String coListAgentTollFreePhone;
+		@JsonProperty("CoListAgentFax")
+		private String coListAgentFax;
+		@JsonProperty("CoListAgentPager")
+		private String coListAgentPager;
+		@JsonProperty("CoListAgentVoiceMail")
+		private String coListAgentVoiceMail;
+		@JsonProperty("CoListAgentVoiceMailExt")
+		private String coListAgentVoiceMailExt;
+		@JsonProperty("CoListAgentEmail")
+		private String coListAgentEmail;
+		@JsonProperty("CoListAgentURL")
+		private String coListAgentURL;
+		@JsonProperty("CoListAgentStateLicense")
+		private String coListAgentStateLicense;
+		@JsonProperty("CoListAgentDesignation")
+		private String coListAgentDesignation;
+		@JsonProperty("CoListOfficeName")
+		private String coListOfficeName;
+		@JsonProperty("CoListOfficePhone")
+		private String coListOfficePhone;
+		@JsonProperty("CoListOfficePhoneExt")
+		private String coListOfficePhoneExt;
+		@JsonProperty("CoListOfficeFax")
+		private String coListOfficeFax;
+		@JsonProperty("CoListOfficeEmail")
+		private String coListOfficeEmail;
+		@JsonProperty("CoListOfficeURL")
+		private String coListOfficeURL;
+		@JsonProperty("VirtualTourURLBranded")
+		private String virtualTourURLBranded;
+		@JsonProperty("VirtualTourURLUnbranded")
+		private String virtualTourURLUnbranded;
+		@JsonProperty("Supplement")
+		private String supplement;
+		@JsonProperty("ModificationTimestamp")
+		private DateField modificationTimestamp;
+
+		
+		public String getListingKey() {
+			return listingKey;
 		}
-		public void setStreetNumber(String streetNumber) {
-			this.streetNumber = streetNumber;
-		}
-		public String getLongitude() {
-			return longitude;
-		}
-		public void setLongitude(String longitude) {
-			this.longitude = longitude;
-		}
-		public String getCity() {
-			return city;
-		}
-		public void setCity(String city) {
-			this.city = city;
+		public void setListingKey( String listingKey ) {
+			this.listingKey = listingKey;
 		}
 		public String getListingId() {
 			return listingId;
 		}
-		public void setListingId(String listingId) {
+		public void setListingId( String listingId ) {
 			this.listingId = listingId;
-		}
-		public String getPublicRemarks() {
-			return publicRemarks;
-		}
-		public void setPublicRemarks(String publicRemarks) {
-			this.publicRemarks = publicRemarks;
-		}
-		public String getBuildingAreaTotal() {
-			return buildingAreaTotal;
-		}
-		public void setBuildingAreaTotal(String buildingAreaTotal) {
-			this.buildingAreaTotal = buildingAreaTotal;
-		}
-		public int getYearBuilt() {
-			return yearBuilt;
-		}
-		public void setYearBuilt(int yearBuilt) {
-			this.yearBuilt = yearBuilt;
-		}
-		public String getStreetName() {
-			return streetName;
-		}
-		public void setStreetName(String streetName) {
-			this.streetName = streetName;
-		}
-		public Double getListPrice() {
-			return listPrice;
-		}
-		public void setListPrice(Double listPrice) {
-			this.listPrice = listPrice;
-		}
-		public String getPostalCode() {
-			return postalCode;
-		}
-		public void setPostalCode(String postalCode) {
-			this.postalCode = postalCode;
-		}
-		public String getLatitude() {
-			return latitude;
-		}
-		public void setLatitude(String latitude) {
-			this.latitude = latitude;
-		}
-		public String getBathsThreeQuarter() {
-			return bathsThreeQuarter;
-		}
-		public void setBathsThreeQuarter(String bathsThreeQuarter) {
-			this.bathsThreeQuarter = bathsThreeQuarter;
-		}
-		public String getBathsFull() {
-			return bathsFull;
-		}
-		public void setBathsFull(String bathsFull) {
-			this.bathsFull = bathsFull;
-		}
-		public Double getBathsTotal() {
-			return bathsTotal;
-		}
-		public void setBathsTotal(Double bathsTotal) {
-			this.bathsTotal = bathsTotal;
-		}
-		public String getStateOrProvince() {
-			return stateOrProvince;
-		}
-		public void setStateOrProvince(String stateOrProvince) {
-			this.stateOrProvince = stateOrProvince;
 		}
 		public String getPropertyType() {
 			return propertyType;
 		}
-		public void setPropertyType(String propertyType) {
+		public void setPropertyType( String propertyType ) {
 			this.propertyType = propertyType;
 		}
-		public String getStreetAdditionalInfo() {
-			return streetAdditionalInfo;
+		public String getPropertySubType() {
+			return propertySubType;
 		}
-		public void setStreetAdditionalInfo(String streetAdditionalInfo) {
-			this.streetAdditionalInfo = streetAdditionalInfo;
+		public void setPropertySubType( String propertySubType ) {
+			this.propertySubType = propertySubType;
+		}
+		public DoubleField getListPrice() {
+			return listPrice;
+		}
+		public void setListPrice( DoubleField listPrice ) {
+			this.listPrice = listPrice;
+		}
+		public String getStreetNumber() {
+			return streetNumber;
+		}
+		public void setStreetNumber( String streetNumber ) {
+			this.streetNumber = streetNumber;
 		}
 		public String getStreetDirPrefix() {
 			return streetDirPrefix;
 		}
-		public void setStreetDirPrefix(String streetDirPrefix) {
+		public void setStreetDirPrefix( String streetDirPrefix ) {
 			this.streetDirPrefix = streetDirPrefix;
 		}
-		public String getBedsTotal() {
-			return bedsTotal;
+		public String getStreetName() {
+			return streetName;
 		}
-		public void setBedsTotal(String bedsTotal) {
-			this.bedsTotal = bedsTotal;
+		public void setStreetName( String streetName ) {
+			this.streetName = streetName;
+		}
+		public String getStreetSuffix() {
+			return streetSuffix;
+		}
+		public void setStreetSuffix( String streetSuffix ) {
+			this.streetSuffix = streetSuffix;
 		}
 		public String getStreetDirSuffix() {
 			return streetDirSuffix;
 		}
-		public void setStreetDirSuffix(String streetDirSuffix) {
+		public void setStreetDirSuffix( String streetDirSuffix ) {
 			this.streetDirSuffix = streetDirSuffix;
 		}
-		public String getListingKey() {
-			return listingKey;
+		public String getStreetAdditionalInfo() {
+			return streetAdditionalInfo;
 		}
-		public void setListingKey(String listingKey) {
-			this.listingKey = listingKey;
+		public void setStreetAdditionalInfo( String streetAdditionalInfo ) {
+			this.streetAdditionalInfo = streetAdditionalInfo;
 		}
-		public String getListOfficeName() {
-			return listOfficeName;
+		public String getCity() {
+			return city;
 		}
-		public void setListOfficeName(String listOfficeName) {
-			this.listOfficeName = listOfficeName;
+		public void setCity( String city ) {
+			this.city = city;
 		}
-		public String getBathsHalf() {
+		public String getStateOrProvince() {
+			return stateOrProvince;
+		}
+		public void setStateOrProvince( String stateOrProvince ) {
+			this.stateOrProvince = stateOrProvince;
+		}
+		public String getPostalCode() {
+			return postalCode;
+		}
+		public void setPostalCode( String postalCode ) {
+			this.postalCode = postalCode;
+		}
+		public IntegerField getYearBuilt() {
+			return yearBuilt;
+		}
+		public void setYearBuilt( IntegerField yearBuilt ) {
+			this.yearBuilt = yearBuilt;
+		}
+		public DoubleField getBuildingAreaTotal() {
+			return buildingAreaTotal;
+		}
+		public void setBuildingAreaTotal( DoubleField buildingAreaTotal ) {
+			this.buildingAreaTotal = buildingAreaTotal;
+		}
+		public IntegerField getBathsThreeQuarter() {
+			return bathsThreeQuarter;
+		}
+		public void setBathsThreeQuarter( IntegerField bathsThreeQuarter ) {
+			this.bathsThreeQuarter = bathsThreeQuarter;
+		}
+		public DoubleField getBathsTotal() {
+			return bathsTotal;
+		}
+		public void setBathsTotal( DoubleField bathsTotal ) {
+			this.bathsTotal = bathsTotal;
+		}
+		public IntegerField getBathsFull() {
+			return bathsFull;
+		}
+		public void setBathsFull( IntegerField bathsFull ) {
+			this.bathsFull = bathsFull;
+		}
+		public IntegerField getBedsTotal() {
+			return bedsTotal;
+		}
+		public void setBedsTotal( IntegerField bedsTotal ) {
+			this.bedsTotal = bedsTotal;
+		}
+		public IntegerField getBathsHalf() {
 			return bathsHalf;
 		}
-		public void setBathsHalf(String bathsHalf) {
+		public void setBathsHalf( IntegerField bathsHalf ) {
 			this.bathsHalf = bathsHalf;
 		}
-		public Date getModificationTimestamp() {
-			return modificationTimestamp;
+		public DoubleField getLongitude() {
+			return longitude;
 		}
-		public void setModificationTimestamp(Date modificationTimestamp) {
-			this.modificationTimestamp = modificationTimestamp;
+		public void setLongitude( DoubleField longitude ) {
+			this.longitude = longitude;
+		}
+		public DoubleField getLatitude() {
+			return latitude;
+		}
+		public void setLatitude( DoubleField latitude ) {
+			this.latitude = latitude;
+		}
+		public String getSubdivisionName() {
+			return subdivisionName;
+		}
+		public void setSubdivisionName( String subdivisionName ) {
+			this.subdivisionName = subdivisionName;
+		}
+		public String getmLSAreaMinor() {
+			return mLSAreaMinor;
+		}
+		public void setmLSAreaMinor( String mLSAreaMinor ) {
+			this.mLSAreaMinor = mLSAreaMinor;
 		}
 		public String getCountyOrParish() {
 			return countyOrParish;
 		}
-		public void setCountyOrParish(String countyOrParish) {
+		public void setCountyOrParish( String countyOrParish ) {
 			this.countyOrParish = countyOrParish;
 		}
+		public String getPublicRemarks() {
+			return publicRemarks;
+		}
+		public void setPublicRemarks( String publicRemarks ) {
+			this.publicRemarks = publicRemarks;
+		}
+		public String getPrivateRemarks() {
+			return privateRemarks;
+		}
+		public void setPrivateRemarks( String privateRemarks ) {
+			this.privateRemarks = privateRemarks;
+		}
+		public String getPrivateOfficeRemarks() {
+			return privateOfficeRemarks;
+		}
+		public void setPrivateOfficeRemarks( String privateOfficeRemarks ) {
+			this.privateOfficeRemarks = privateOfficeRemarks;
+		}
+		public DateField getPendingDate() {
+			return pendingDate;
+		}
+		public void setPendingDate( DateField pendingDate ) {
+			this.pendingDate = pendingDate;
+		}
+		public DateField getCloseDate() {
+			return closeDate;
+		}
+		public void setCloseDate( DateField closeDate ) {
+			this.closeDate = closeDate;
+		}
+		public DateField getCancelDate() {
+			return cancelDate;
+		}
+		public void setCancelDate( DateField cancelDate ) {
+			this.cancelDate = cancelDate;
+		}
+		public DateField getWithdrawDate() {
+			return withdrawDate;
+		}
+		public void setWithdrawDate( DateField withdrawDate ) {
+			this.withdrawDate = withdrawDate;
+		}
+		public String getListAgentFirstName() {
+			return listAgentFirstName;
+		}
+		public void setListAgentFirstName( String listAgentFirstName ) {
+			this.listAgentFirstName = listAgentFirstName;
+		}
+		public String getListAgentMiddleName() {
+			return listAgentMiddleName;
+		}
+		public void setListAgentMiddleName( String listAgentMiddleName ) {
+			this.listAgentMiddleName = listAgentMiddleName;
+		}
+		public String getListAgentLastName() {
+			return listAgentLastName;
+		}
+		public void setListAgentLastName( String listAgentLastName ) {
+			this.listAgentLastName = listAgentLastName;
+		}
+		public String getListAgentPreferredPhone() {
+			return listAgentPreferredPhone;
+		}
+		public void setListAgentPreferredPhone( String listAgentPreferredPhone ) {
+			this.listAgentPreferredPhone = listAgentPreferredPhone;
+		}
+		public String getListAgentPreferredPhoneExt() {
+			return listAgentPreferredPhoneExt;
+		}
+		public void setListAgentPreferredPhoneExt( String listAgentPreferredPhoneExt ) {
+			this.listAgentPreferredPhoneExt = listAgentPreferredPhoneExt;
+		}
+		public String getListAgentOfficePhone() {
+			return listAgentOfficePhone;
+		}
+		public void setListAgentOfficePhone( String listAgentOfficePhone ) {
+			this.listAgentOfficePhone = listAgentOfficePhone;
+		}
+		public String getListAgentOfficePhoneExt() {
+			return listAgentOfficePhoneExt;
+		}
+		public void setListAgentOfficePhoneExt( String listAgentOfficePhoneExt ) {
+			this.listAgentOfficePhoneExt = listAgentOfficePhoneExt;
+		}
+		public String getListAgentCellPhone() {
+			return listAgentCellPhone;
+		}
+		public void setListAgentCellPhone( String listAgentCellPhone ) {
+			this.listAgentCellPhone = listAgentCellPhone;
+		}
+		public String getListAgentDirectPhone() {
+			return listAgentDirectPhone;
+		}
+		public void setListAgentDirectPhone( String listAgentDirectPhone ) {
+			this.listAgentDirectPhone = listAgentDirectPhone;
+		}
+		public String getListAgentTollFreePhone() {
+			return listAgentTollFreePhone;
+		}
+		public void setListAgentTollFreePhone( String listAgentTollFreePhone ) {
+			this.listAgentTollFreePhone = listAgentTollFreePhone;
+		}
+		public String getListAgentFax() {
+			return listAgentFax;
+		}
+		public void setListAgentFax( String listAgentFax ) {
+			this.listAgentFax = listAgentFax;
+		}
+		public String getListAgentPager() {
+			return listAgentPager;
+		}
+		public void setListAgentPager( String listAgentPager ) {
+			this.listAgentPager = listAgentPager;
+		}
+		public String getListAgentVoiceMail() {
+			return listAgentVoiceMail;
+		}
+		public void setListAgentVoiceMail( String listAgentVoiceMail ) {
+			this.listAgentVoiceMail = listAgentVoiceMail;
+		}
+		public String getListAgentVoiceMailExt() {
+			return listAgentVoiceMailExt;
+		}
+		public void setListAgentVoiceMailExt( String listAgentVoiceMailExt ) {
+			this.listAgentVoiceMailExt = listAgentVoiceMailExt;
+		}
+		public String getListAgentEmail() {
+			return listAgentEmail;
+		}
+		public void setListAgentEmail( String listAgentEmail ) {
+			this.listAgentEmail = listAgentEmail;
+		}
+		public String getListAgentURL() {
+			return listAgentURL;
+		}
+		public void setListAgentURL( String listAgentURL ) {
+			this.listAgentURL = listAgentURL;
+		}
+		public String getListAgentStateLicense() {
+			return listAgentStateLicense;
+		}
+		public void setListAgentStateLicense( String listAgentStateLicense ) {
+			this.listAgentStateLicense = listAgentStateLicense;
+		}
+		public String getListAgentDesignation() {
+			return listAgentDesignation;
+		}
+		public void setListAgentDesignation( String listAgentDesignation ) {
+			this.listAgentDesignation = listAgentDesignation;
+		}
+		public String getListOfficeName() {
+			return listOfficeName;
+		}
+		public void setListOfficeName( String listOfficeName ) {
+			this.listOfficeName = listOfficeName;
+		}
+		public String getListOfficePhone() {
+			return listOfficePhone;
+		}
+		public void setListOfficePhone( String listOfficePhone ) {
+			this.listOfficePhone = listOfficePhone;
+		}
+		public String getListOfficePhoneExt() {
+			return listOfficePhoneExt;
+		}
+		public void setListOfficePhoneExt( String listOfficePhoneExt ) {
+			this.listOfficePhoneExt = listOfficePhoneExt;
+		}
+		public String getListOfficeFax() {
+			return listOfficeFax;
+		}
+		public void setListOfficeFax( String listOfficeFax ) {
+			this.listOfficeFax = listOfficeFax;
+		}
+		public String getListOfficeEmail() {
+			return listOfficeEmail;
+		}
+		public void setListOfficeEmail( String listOfficeEmail ) {
+			this.listOfficeEmail = listOfficeEmail;
+		}
+		public String getListOfficeURL() {
+			return listOfficeURL;
+		}
+		public void setListOfficeURL( String listOfficeURL ) {
+			this.listOfficeURL = listOfficeURL;
+		}
+		public String getCoListAgentFirstName() {
+			return coListAgentFirstName;
+		}
+		public void setCoListAgentFirstName( String coListAgentFirstName ) {
+			this.coListAgentFirstName = coListAgentFirstName;
+		}
+		public String getCoListAgentMiddleName() {
+			return coListAgentMiddleName;
+		}
+		public void setCoListAgentMiddleName( String coListAgentMiddleName ) {
+			this.coListAgentMiddleName = coListAgentMiddleName;
+		}
+		public String getCoListAgentLastName() {
+			return coListAgentLastName;
+		}
+		public void setCoListAgentLastName( String coListAgentLastName ) {
+			this.coListAgentLastName = coListAgentLastName;
+		}
+		public String getCoListAgentPreferredPhone() {
+			return coListAgentPreferredPhone;
+		}
+		public void setCoListAgentPreferredPhone( String coListAgentPreferredPhone ) {
+			this.coListAgentPreferredPhone = coListAgentPreferredPhone;
+		}
+		public String getCoListAgentPreferredPhoneExt() {
+			return coListAgentPreferredPhoneExt;
+		}
+		public void setCoListAgentPreferredPhoneExt( String coListAgentPreferredPhoneExt ) {
+			this.coListAgentPreferredPhoneExt = coListAgentPreferredPhoneExt;
+		}
+		public String getCoListAgentOfficePhone() {
+			return coListAgentOfficePhone;
+		}
+		public void setCoListAgentOfficePhone( String coListAgentOfficePhone ) {
+			this.coListAgentOfficePhone = coListAgentOfficePhone;
+		}
+		public String getCoListAgentOfficePhoneExt() {
+			return coListAgentOfficePhoneExt;
+		}
+		public void setCoListAgentOfficePhoneExt( String coListAgentOfficePhoneExt ) {
+			this.coListAgentOfficePhoneExt = coListAgentOfficePhoneExt;
+		}
+		public String getCoListAgentCellPhone() {
+			return coListAgentCellPhone;
+		}
+		public void setCoListAgentCellPhone( String coListAgentCellPhone ) {
+			this.coListAgentCellPhone = coListAgentCellPhone;
+		}
+		public String getCoListAgentDirectPhone() {
+			return coListAgentDirectPhone;
+		}
+		public void setCoListAgentDirectPhone( String coListAgentDirectPhone ) {
+			this.coListAgentDirectPhone = coListAgentDirectPhone;
+		}
+		public String getCoListAgentTollFreePhone() {
+			return coListAgentTollFreePhone;
+		}
+		public void setCoListAgentTollFreePhone( String coListAgentTollFreePhone ) {
+			this.coListAgentTollFreePhone = coListAgentTollFreePhone;
+		}
+		public String getCoListAgentFax() {
+			return coListAgentFax;
+		}
+		public void setCoListAgentFax( String coListAgentFax ) {
+			this.coListAgentFax = coListAgentFax;
+		}
+		public String getCoListAgentPager() {
+			return coListAgentPager;
+		}
+		public void setCoListAgentPager( String coListAgentPager ) {
+			this.coListAgentPager = coListAgentPager;
+		}
+		public String getCoListAgentVoiceMail() {
+			return coListAgentVoiceMail;
+		}
+		public void setCoListAgentVoiceMail( String coListAgentVoiceMail ) {
+			this.coListAgentVoiceMail = coListAgentVoiceMail;
+		}
+		public String getCoListAgentVoiceMailExt() {
+			return coListAgentVoiceMailExt;
+		}
+		public void setCoListAgentVoiceMailExt( String coListAgentVoiceMailExt ) {
+			this.coListAgentVoiceMailExt = coListAgentVoiceMailExt;
+		}
+		public String getCoListAgentEmail() {
+			return coListAgentEmail;
+		}
+		public void setCoListAgentEmail( String coListAgentEmail ) {
+			this.coListAgentEmail = coListAgentEmail;
+		}
+		public String getCoListAgentURL() {
+			return coListAgentURL;
+		}
+		public void setCoListAgentURL( String coListAgentURL ) {
+			this.coListAgentURL = coListAgentURL;
+		}
+		public String getCoListAgentStateLicense() {
+			return coListAgentStateLicense;
+		}
+		public void setCoListAgentStateLicense( String coListAgentStateLicense ) {
+			this.coListAgentStateLicense = coListAgentStateLicense;
+		}
+		public String getCoListAgentDesignation() {
+			return coListAgentDesignation;
+		}
+		public void setCoListAgentDesignation( String coListAgentDesignation ) {
+			this.coListAgentDesignation = coListAgentDesignation;
+		}
+		public String getCoListOfficeName() {
+			return coListOfficeName;
+		}
+		public void setCoListOfficeName( String coListOfficeName ) {
+			this.coListOfficeName = coListOfficeName;
+		}
+		public String getCoListOfficePhone() {
+			return coListOfficePhone;
+		}
+		public void setCoListOfficePhone( String coListOfficePhone ) {
+			this.coListOfficePhone = coListOfficePhone;
+		}
+		public String getCoListOfficePhoneExt() {
+			return coListOfficePhoneExt;
+		}
+		public void setCoListOfficePhoneExt( String coListOfficePhoneExt ) {
+			this.coListOfficePhoneExt = coListOfficePhoneExt;
+		}
+		public String getCoListOfficeFax() {
+			return coListOfficeFax;
+		}
+		public void setCoListOfficeFax( String coListOfficeFax ) {
+			this.coListOfficeFax = coListOfficeFax;
+		}
+		public String getCoListOfficeEmail() {
+			return coListOfficeEmail;
+		}
+		public void setCoListOfficeEmail( String coListOfficeEmail ) {
+			this.coListOfficeEmail = coListOfficeEmail;
+		}
+		public String getCoListOfficeURL() {
+			return coListOfficeURL;
+		}
+		public void setCoListOfficeURL( String coListOfficeURL ) {
+			this.coListOfficeURL = coListOfficeURL;
+		}
+		public String getVirtualTourURLBranded() {
+			return virtualTourURLBranded;
+		}
+		public void setVirtualTourURLBranded( String virtualTourURLBranded ) {
+			this.virtualTourURLBranded = virtualTourURLBranded;
+		}
+		public String getVirtualTourURLUnbranded() {
+			return virtualTourURLUnbranded;
+		}
+		public void setVirtualTourURLUnbranded( String virtualTourURLUnbranded ) {
+			this.virtualTourURLUnbranded = virtualTourURLUnbranded;
+		}
+		public String getSupplement() {
+			return supplement;
+		}
+		public void setSupplement( String supplement ) {
+			this.supplement = supplement;
+		}
+		public DateField getModificationTimestamp() {
+			return modificationTimestamp;
+		}
+		public void setModificationTimestamp( DateField modificationTimestamp ) {
+			this.modificationTimestamp = modificationTimestamp;
+		}
 		
-		public String getStreetSuffix() {
-			return streetSuffix;
-		}
-		public void setStreetSuffix(String streetSuffix) {
-			this.streetSuffix = streetSuffix;
-		}
 		
 	    @JsonProperty("Documents")
 	    private List<Document> documents;

--- a/src/main/java/com/sparkplatform/api/models/StandardField.java
+++ b/src/main/java/com/sparkplatform/api/models/StandardField.java
@@ -56,7 +56,7 @@ public class StandardField extends Base {
 				JsonProcessingException {
 			JavaType jt = TypeFactory.mapType(Map.class, String.class, Field.class);
 			DeserializerProvider deserializerProvider = ctxt.getDeserializerProvider();
-			JsonDeserializer<Object> z = deserializerProvider.findTypedValueDeserializer(ctxt.getConfig(), jt);
+			JsonDeserializer<Object> z = deserializerProvider.findTypedValueDeserializer(ctxt.getConfig(), jt, null);
 			@SuppressWarnings("unchecked")
 			Map<String, Field>o = (Map<String, Field>)z.deserialize(jp, ctxt);
 			if(o == null) {


### PR DESCRIPTION
and that is causing the following error: {
  "error" : "invalid_request",
  "error_description" : "Authorization code may not be used more than
once" }

bug fix: When a non-text field is restricted by MLS, ******** is
causing exception in the parser. Custom types added.

Also updated version of org.codehaus.jackson - the old one didn't support custom types for double JSON fields.